### PR TITLE
Do not clear DateField on invalid input

### DIFF
--- a/src/DateTimeField.js
+++ b/src/DateTimeField.js
@@ -72,7 +72,11 @@ export default class DateTimeField extends Component {
       if (moment(nextProps.defaultText, nextProps.inputFormat, true).isValid()){
         state.inputValue = nextProps.defaultText;
       }else if (this.props.defaultText !== ''){
-        state.inputValue = '';
+        // Note: state.inputValue = ''; is removed so the date field is not cleared on failing validation
+        // This is a quick fix to the bug where going from a valid date to an invalid date
+        // when typing consumes the first character of invalid input.
+        // See: Pivotal #111849691
+        // state.inputValue = '';
       }
     }
 


### PR DESCRIPTION
This is a quick fix to having the first character of an invalid input being consumed. Instead of clearing the field after inserting a character which invalidates the entire field, we simply do not clear this field.

See: Pivotal #111849691
